### PR TITLE
Set result.ReferencedAssemblies when -r switch is on

### DIFF
--- a/AssemblyInfo/Program.cs
+++ b/AssemblyInfo/Program.cs
@@ -124,7 +124,7 @@ namespace AssemblyInfo
                 {
                     System.Console.WriteLine("\nReferenced Assemblies");
                     var referencedAssemblies = asm.GetReferencedAssemblies().OrderBy(n => n.Name);
-                    result.ReferencedAssemblies = types.Select(t => t.Name).ToList();
+                    result.ReferencedAssemblies = referencedAssemblies.Select(r => r.Name).ToList();
                     
                     foreach (var a in referencedAssemblies)
                     {

--- a/AssemblyInfo/Program.cs
+++ b/AssemblyInfo/Program.cs
@@ -124,6 +124,8 @@ namespace AssemblyInfo
                 {
                     System.Console.WriteLine("\nReferenced Assemblies");
                     var referencedAssemblies = asm.GetReferencedAssemblies().OrderBy(n => n.Name);
+                    result.ReferencedAssemblies = types.Select(t => t.Name).ToList();
+                    
                     foreach (var a in referencedAssemblies)
                     {
                         System.Console.WriteLine("  " + a.Name);


### PR DESCRIPTION
We need to set result.ReferencedAssemblies property when -r switch is on, so that the referenced assemblies are also sent to output.